### PR TITLE
implemented simple-jekyll-search with filter buttons

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,7 @@ collections:
   - interviews
   - authors
   - PMs
+  - politicians
 
 #social settings
 facebook_url:  https://www.facebook.com/wisebooksio/

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -60,19 +60,8 @@
 <script src="{{ "assets/js/jquery.details.js" | absolute_url }}"></script>
 <script src="{{ "assets/js/jquery.scrolly.min.js" | absolute_url }}"></script>
 <script src="{{ "assets/js/jquery.scrollex.min.js" | absolute_url }}"></script>
-<script src="{{ "assets/js/jekyll-search.js" | absolute_url }}"></script>
-<script>
-	SimpleJekyllSearch({
-	  searchInput: document.getElementById('search-input'),
-	  resultsContainer: document.getElementById('results-container'),
-	  json: '{{site.baseurl}}/search.json',
-	  searchResultTemplate: '<li><a href="{url}" title="{desc}">{title}</a></li>',
-	  noResultsText: 'No results found',
-	  fuzzy: false,
-	  exclude: ['Welcome']
-	});
-  </script>
 <script src="https://cdn.rawgit.com/christian-fei/Simple-Jekyll-Search/master/dest/simple-jekyll-search.min.js"></script>
+<script src="{{ "assets/js/custom-search.js" | absolute_url }}"></script>
 <script src="https://unpkg.com/isotope-layout@3.0/dist/isotope.pkgd.js"></script>
 <script src="https://unpkg.com/imagesloaded@4/imagesloaded.pkgd.min.js"></script>
 <script src="{{ "assets/js/isotope.js" | absolute_url }}"></script>

--- a/_layouts/allposts.html
+++ b/_layouts/allposts.html
@@ -37,7 +37,7 @@
 				<div class="search-result box {{ post.category }}">
 
 						<h2 class="underline">{{post.title}}</h2>
-						{% if post.allpeoplepics %}<span class="image-container"><img class="peopleimg" src="{{ site.baseurl }}/{{ post.allpeoplepics }}" alt="{{post.title}}" /></span>{% endif %}
+						{% if post.allpeoplepics %}<div class="image-container"><img class="peopleimg" src="{{ site.baseurl }}/{{ post.allpeoplepics }}" alt="{{post.title}}" /></div>{% endif %}
 						<div class="box-description">
 							<p>{{ post.description }}</p>
 							<a href="{{ post.url | relative_url  }}" class="button small align-right">Read more</a>

--- a/_layouts/allposts.html
+++ b/_layouts/allposts.html
@@ -16,12 +16,10 @@
 	<div class="inner">
 		<header class="major-yellow"><h1>All People</h1></header>
 
-		<!--div id="search-container">
-			<input type="text" id="search-input" placeholder="search...">
-			<ul id="results-container"></ul>
-		</div-->
-			
-		<section id="filters">
+		<div id="search-container">
+			<span class="icon fa-search"></span>
+			<input type="text" id="search-input" label="Search" placeholder="Search for people...">
+			<section id="filters">
 				<div class="button-group filter-button-group">
 					{% assign sorted = site.categories | sort %}
 						{% for category in sorted %}
@@ -30,14 +28,16 @@
 							<a class="button active" id="all" data-filter="*">All</a>
 				</div>
 
-		</section>
-
-		<div class="innerpeople">
+			</section>
+			<div id="results-container" class="search-results"></div>
+		</div>
+			
+		<div class="search-results" id="all-results">
 				{% for post in site.posts %}
-				<div class="box {{ post.category }}">
+				<div class="search-result box {{ post.category }}">
 
 						<h2 class="underline">{{post.title}}</h2>
-						{% if post.allpeoplepics %}<span class="image left"><img class="peopleimg" src="{{ site.baseurl }}/{{ post.allpeoplepics }}" alt="{{post.title}}" /></span>{% endif %}
+						{% if post.allpeoplepics %}<span class="image-container"><img class="peopleimg" src="{{ site.baseurl }}/{{ post.allpeoplepics }}" alt="{{post.title}}" /></span>{% endif %}
 						<div class="box-description">
 							<p>{{ post.description }}</p>
 							<a href="{{ post.url | relative_url  }}" class="button small align-right">Read more</a>
@@ -46,6 +46,8 @@
 
 				{% endfor %}
 		</div> 
+
+	
 		
 	</div>
 </section>

--- a/_sass/components/_button.scss
+++ b/_sass/components/_button.scss
@@ -30,7 +30,7 @@
 		text-transform: uppercase;
 		white-space: nowrap;
 
-		&:hover, &:active {
+		&:hover, &:active, &.selected {
 			box-shadow: inset 0 0 0 2px _palette(highlight);
 			color: _palette(highlight);
 			background-color: _palette(accent3);

--- a/_sass/components/_form.scss
+++ b/_sass/components/_form.scss
@@ -235,6 +235,10 @@
 			border-color: _palette(highlight);
 			box-shadow: 0 0 0 2px _palette(highlight);
 		}
+
+		&::placeholder {
+			color: #1a2930;
+		}
 	}
 
 	.select-wrapper {

--- a/_sass/layout/_allposts.scss
+++ b/_sass/layout/_allposts.scss
@@ -1,97 +1,91 @@
 
 /* allposts */
 
-#filters {
-    margin-bottom: 2em;
+#allposts {
 
-    .button-group {
-    
-        .button {
-            margin: 0.5em;
+    header.major-yellow {
+        margin: 0 auto;
+
+        h1 {
+            text-align: center;
         }
     }
-}
 
-	.innerpeople {
-		display: flex;
-		flex-wrap: wrap;
-		.box {
-			width: 48%;
-            margin-left: 1em;
-            .peopleimg {
-                width: 100%;
-            }
-            .box-description {
-                width: 55%;
-                float: right;
-            }
+    #search-container {
+        position: relative;
+        width: 80%;
+        margin: 0 auto;
+        margin-top: 3em;
 
-		}
+        .fa-search {
+            position: absolute;
+            right: 1rem;
+            top: .6rem;
+        }
+        input::placeholder {
+            color: #1a2930 !important;
+        }
     }
 
-	@include breakpoint(medium) {
-		.innerpeople {
-			.box {
-				width: 100%;
-                margin-left: 0;
-                margin-top: 2em;
-			}
-		}	
+
+    #filters {
+        margin: 2em 0 2em 0;
+
+        .button-group {
+            display: flex;
+            flex-wrap: wrap;
+
+
+        
+            .button {
+                margin: 0.5em;
+            }
+        }
     }
-    
+
+    .search-result {
+        .image-container {
+            width: 100%;
+        }
+
+        h2 {
+            text-align: center;
+        }
+
+        .peopleimg {
+            max-width: 210px;
+            height: auto;
+            border-radius: 3px;
+            display: flex;
+            margin: 0 auto;
+        }
+
+        .box-description {
+            text-align: center;
+            margin: 1em 0 0 0;
+
+        }
+
+    }
+
+    #results-container, #all-results {
+        display: flex;
+        flex-wrap: wrap;
+        .search-result {
+            flex: 1 0 30%;
+            margin: 5px;
+            height: auto;
+        }
+    }
+
+    @include breakpoint(medium) {
+
+    }
+
     @include breakpoint(small) {
         #filters {
             margin-bottom: 0;
         }
-        .innerpeople {
-            .box {
-                display: flex;
-                flex-direction: column;
-                h2 {
-                    text-align: center;
-                }
-                .image {
-                    margin: 0 auto;
-                    width: 90% !important;
-                    margin-bottom: 1em;
-                    height: auto;
-                    
-                }
-                .box-description {
-                    width: 100%;
-                    float: none;
-                    text-align: center;
-                }
-            }
 
-        }
-    }
-
-.peopleimg {
-    max-width: 210px;
-    height: auto;
-    border-radius: 3px;
-}
-
-#search-container {
-    position: relative;
-
-    .fa-search {
-        position: absolute;
-        right: 1rem;
-        top: .6rem;
-    }
-    input::placeholder {
-        color: #1a2930 !important;
-    }
-}
-
-#results-container, #all-results {
-    display: flex;
-    flex-wrap: wrap;
-    .search-result {
-        flex: 1 0 30%;
-        margin: 5px;
-        height: auto;
     }
 }

--- a/_sass/layout/_allposts.scss
+++ b/_sass/layout/_allposts.scss
@@ -66,3 +66,32 @@
 
         }
     }
+
+.peopleimg {
+    max-width: 210px;
+    height: auto;
+    border-radius: 3px;
+}
+
+#search-container {
+    position: relative;
+
+    .fa-search {
+        position: absolute;
+        right: 1rem;
+        top: .6rem;
+    }
+    input::placeholder {
+        color: #1a2930 !important;
+    }
+}
+
+#results-container, #all-results {
+    display: flex;
+    flex-wrap: wrap;
+    .search-result {
+        flex: 1 0 30%;
+        margin: 5px;
+        height: auto;
+    }
+}

--- a/assets/js/custom-search.js
+++ b/assets/js/custom-search.js
@@ -1,0 +1,54 @@
+var sjs = SimpleJekyllSearch({
+    searchInput: document.getElementById('search-input'),
+    resultsContainer: document.getElementById('results-container'),
+    searchResultTemplate: '<div class="search-result box { category }"><h2 class="underline">{title}</h2><div class="img-container"><img class="peopleimg" src="{allpeoplepics}" alt="{title}" /></div><div class="box-description"><p>{description}</p><a href="{url}" class="button small align-right">Read more</a></div></div>',
+    json: '/search.json',
+    exclude: ['Welcome']
+})
+
+doSearch(); // run once on page load
+
+$('.button-group a ').click(e => {
+    // add selected to clicked button
+    if (e.target.className.indexOf('selected') >= 0) {
+        e.target.className = 'button';
+    }
+    else {
+        e.target.className = 'button selected';
+    }
+    doSearch();
+});
+
+$('#search-input').on('input', function(e) {
+    doSearch()
+});
+
+function doSearch() {
+
+    const filterList = document.getElementsByClassName('button selected'); // all selected
+    const currentInput = document.getElementById('search-input').value;
+    var filters = ''; // string of filters
+
+    for (var i = 0; i< filterList.length; i++) {
+        var newFilter = filterList[i].getAttribute('data-filter').split('.')[1];
+        if (filters.length === 0 && currentInput === '' || currentInput === undefined) {
+            filters = filters.concat(newFilter);
+        }
+        else {
+            filters = filters.concat(' && ', newFilter);
+        }
+    }; 
+
+    
+    var toSearch = currentInput.concat(filters);
+    if (!toSearch.length && !filters.length) {
+        // no query or filters, show everything
+        document.getElementById('all-results').style.display = 'flex';
+        document.getElementById('results-container').style.display = 'none';
+    }
+    else {
+        document.getElementById('all-results').style.display = 'none';
+        document.getElementById('results-container').style.display = 'flex';
+        sjs.search(toSearch);
+    }
+}

--- a/search.json
+++ b/search.json
@@ -8,7 +8,9 @@ layout: null
       "category" : "{{ post.category }}",
       "tags"     : "{{ post.tags | join: ', ' }}",
       "url"      : "{{ site.baseurl }}{{ post.url }}",
-      "date"     : "{{ post.date }}"
+      "date"     : "{{ post.date }}",
+      "description": "{{ post.description | strip_html | strip_newlines | remove_chars | escape }}",
+      "allpeoplepics": "{{ site.baseurl }}/{{ post.allpeoplepics }}"
     } {% unless forloop.last %},{% endunless %}
   {% endfor %}
 ]


### PR DESCRIPTION
- Search now works, along with filters
- Also searches text in their description, which can make a few more results pop up than just their category.
- Used flex for the grid instead of absolute positioning, makes it a bit easier to manage.
- Sadly, the search plugin filtering doesn't allow filters to be "AND" logic, so if you search "Natalie" but also doctor, you'll get things with natalie, or things with doctors, but not Natalies who are Doctors.
- If you aren't searching for anything or you've turned off a filter with no search, it goes back to the full list of results